### PR TITLE
Mod data source of xgboost_customer_churn notebooks

### DIFF
--- a/xgboost_customer_churn/xgboost_customer_churn.ipynb
+++ b/xgboost_customer_churn/xgboost_customer_churn.ipynb
@@ -73,6 +73,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sklearn.datasets import fetch_openml\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
@@ -96,9 +97,9 @@
     "\n",
     "携帯電話会社は、どの顧客が最終的に離反したか、または、サービスを使い続けたかの履歴データをもっています。この履歴データに対して学習を行うことで、携帯電話会社の顧客離反を予想するモデルを構築します。モデルの学習が終わった後、任意の顧客のデータ (モデルの学習で利用したものと同じ情報を利用します）をモデルに入力すると、モデルはその顧客が離反しそうかどうかを予測します。もちろん、モデルは誤って予測することも考えられるので、将来を予測することはやはり難しいですが、そのような誤りに対応する方法も紹介します。\n",
     "\n",
-    "ここで利用するデータセットは一般的に利用可能で、書籍 [Discovering Knowledge in Data](https://www.amazon.com/dp/0470908742/) の中で Daniel T. Larose が言及しているものです。そのデータセットは、著者によって University of California Irvine Repository of Machine Learning Datasets に提供されています。ここでは、そのデーセットをダウンロードして読み込んでみます。\n",
+    "ここで利用するデータセットは一般的に利用可能で、書籍 [Discovering Knowledge in Data](https://www.amazon.com/dp/0470908742/) の中で Daniel T. Larose が言及しているものです。そのデータセットは、[OpenML](https://www.openml.org/d/40701)で公開されています。\n",
     "\n",
-    "Jupyter notebook では、冒頭に `!` を入力することで、シェルコマンドを実行することができます。`wget` を利用してファイルをダウンロードし、`unzip` で展開します。"
+    "機械学習ライブラリである`scikit-learn`でOpenMLからデータを取得、`pandas` を利用して読み込んでいます。 `pandas` は、表形式のデータを読み込んで、様々な加工ができるライブラリです。例えば、以下を実行すると表形式でのデータ表示が可能です。"
    ]
   },
   {
@@ -107,33 +108,40 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget http://dataminingconsultant.com/DKD2e_data_sets.zip\n",
-    "!unzip -o DKD2e_data_sets.zip"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "展開すると `./Data sets/` 以下にデータが展開されます。`churn.txt` を `pandas` を利用して読み込んでみます。 `pandas` は、表形式のデータを読み込んで、様々な加工ができるライブラリです。例えば、以下を実行すると表形式でのデータ表示が可能です。"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "churn = pd.read_csv('./Data sets/churn.txt')\n",
+    "dataDict = fetch_openml('churn')\n",
+    "\n",
+    "churn_array = np.concatenate((dataDict['data'], dataDict['target'].reshape(5000,1)), axis=1)\n",
+    "\n",
+    "feature_names = [\"State\", \"Account Length\", \"Area Code\", \"Phone\", \n",
+    "                 \"Int'l Plan\", \"VMail Plan\", \"VMail Message\",\"Day Mins\",\n",
+    "                 \"Day Calls\", \"Day Charge\", \"Eve Mins\", \"Eve Calls\",\n",
+    "                 \"Eve Charge\", \"Night Mins\", \"Night Calls\",\"Night Charge\",\n",
+    "                 \"Intl Mins\", \"Intl Calls\", \"Intl Charge\", \"CustServ Calls\", \"Churn?\"]\n",
+    "\n",
+    "feature_dtypes = {\"State\":\"int64\", \"Account Length\":\"int64\", \"Area Code\":\"int64\",\n",
+    "                  \"Phone\":\"object\", \"Int'l Plan\":\"object\", \"VMail Plan\":\"object\", \n",
+    "                  \"VMail Message\":\"int64\",\"Day Mins\":\"float64\", \"Day Calls\":\"int64\",\"Day Charge\":\"float64\",\n",
+    "                  \"Eve Mins\":\"float64\",  \"Eve Calls\":\"int64\", \"Eve Charge\":\"float64\",\n",
+    "                  \"Night Mins\": \"float64\",\n",
+    "                  \"Night Calls\":\"int64\", \"Night Charge\":\"float64\", \"Intl Mins\":\"float64\", \n",
+    "                  \"Intl Calls\":\"int64\", \"CustServ Calls\":\"int64\",\n",
+    "                  \"Churn?\":\"object\"}\n",
+    "\n",
+    "churn = pd.DataFrame(data=churn_array, columns=feature_names).astype(feature_dtypes)\n",
+    "\n",
+    "churn[\"Int'l Plan\"] = churn[\"Int'l Plan\"].map({1:\"yes\", 0:\"no\"})\n",
+    "churn[\"VMail Plan\"] = churn[\"VMail Plan\"].map({1:\"yes\", 0:\"no\"})\n",
+    "churn[\"Churn?\"] = churn[\"Churn?\"].map({\"1\":\"True.\", \"0\":\"False.\"})\n",
+    "\n",
     "pd.set_option('display.max_columns', 500)\n",
-    "churn"
+    "churn.head()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "データをみると 3,333 行のデータしかなく、現在の機械学習の状況から見ると、やや小さいデータセットです。各データのレコードは、ある米国の携帯電話会社の顧客のプロフィールを説明する21の属性からなります。その属性というのは、\n",
+    "データをみると 5,000 行のデータしかなく、現在の機械学習の状況から見ると、やや小さいデータセットです。各データのレコードは、ある米国の携帯電話会社の顧客のプロフィールを説明する21の属性からなります。その属性というのは、\n",
     "\n",
     "- `State`: 顧客が居住している米国州で、2文字の省略形で記載されます (OHとかNJのように)\n",
     "- `Account Length`: アカウントが利用可能になってからの経過日数\n",
@@ -613,6 +621,13 @@
    "source": [
     "sagemaker.Session().delete_endpoint(xgb_predictor.endpoint)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -636,5 +651,5 @@
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/xgboost_customer_churn/xgboost_customer_churn_neo.ipynb
+++ b/xgboost_customer_churn/xgboost_customer_churn_neo.ipynb
@@ -98,7 +98,9 @@
     "\n",
     "携帯電話事業者はどの顧客が解約し、誰がサービスを継続利用しているかの履歴データを持っています。この過去の情報を使って ML モデルを学習させることにより、ある事業者の解約率を予測するモデルを構築することができます。モデルを学習させた後、任意の顧客情報 (学習に使った情報と同様のもの) をモデルに入力することによって、顧客が解約しようとしているかを予測することができます。もちろん、モデルが予測を間違えることもあります -- 結局のところ、未来を予測することは一筋縄ではいかないということなのです。しかし、ここではその予測誤差とどう付き合っていくかについても言及します。\n",
     "\n",
-    "今回扱うのは、Daniel T. Larose の [Discovering Knowledge in Data](https://www.amazon.com/dp/0470908742/) という本で述べられている公開データセットです。これは University of California Irvine (UCI) 機械学習レポジトリの著者に帰属します。さて、ダウンロードしてデータセットを見てみましょう: "
+    "ここで利用するデータセットは一般的に利用可能で、書籍 [Discovering Knowledge in Data](https://www.amazon.com/dp/0470908742/) の中で Daniel T. Larose が言及しているものです。そのデータセットは、[OpenML](https://www.openml.org/d/40701)で公開されています。\n",
+    "\n",
+    "機械学習ライブラリである`scikit-learn`でOpenMLからデータを取得、`pandas` を利用して読み込んでいます。 `pandas` は、表形式のデータを読み込んで、様々な加工ができるライブラリです。例えば、以下を実行すると表形式でのデータ表示が可能です。"
    ]
   },
   {
@@ -107,17 +109,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget http://dataminingconsultant.com/DKD2e_data_sets.zip\n",
-    "!unzip -o DKD2e_data_sets.zip"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "churn = pd.read_csv('./Data sets/churn.txt')\n",
+    "dataDict = fetch_openml('churn')\n",
+    "\n",
+    "churn_array = np.concatenate((dataDict['data'], dataDict['target'].reshape(5000,1)), axis=1)\n",
+    "\n",
+    "feature_names = [\"State\", \"Account Length\", \"Area Code\", \"Phone\", \n",
+    "                 \"Int'l Plan\", \"VMail Plan\", \"VMail Message\",\"Day Mins\",\n",
+    "                 \"Day Calls\", \"Day Charge\", \"Eve Mins\", \"Eve Calls\",\n",
+    "                 \"Eve Charge\", \"Night Mins\", \"Night Calls\",\"Night Charge\",\n",
+    "                 \"Intl Mins\", \"Intl Calls\", \"Intl Charge\", \"CustServ Calls\", \"Churn?\"]\n",
+    "\n",
+    "feature_dtypes = {\"State\":\"int64\", \"Account Length\":\"int64\", \"Area Code\":\"int64\",\n",
+    "                  \"Phone\":\"object\", \"Int'l Plan\":\"object\", \"VMail Plan\":\"object\", \n",
+    "                  \"VMail Message\":\"int64\",\"Day Mins\":\"float64\", \"Day Calls\":\"int64\",\"Day Charge\":\"float64\",\n",
+    "                  \"Eve Mins\":\"float64\",  \"Eve Calls\":\"int64\", \"Eve Charge\":\"float64\",\n",
+    "                  \"Night Mins\": \"float64\",\n",
+    "                  \"Night Calls\":\"int64\", \"Night Charge\":\"float64\", \"Intl Mins\":\"float64\", \n",
+    "                  \"Intl Calls\":\"int64\", \"CustServ Calls\":\"int64\",\n",
+    "                  \"Churn?\":\"object\"}\n",
+    "\n",
+    "churn = pd.DataFrame(data=churn_array, columns=feature_names).astype(feature_dtypes)\n",
+    "\n",
+    "churn[\"Int'l Plan\"] = churn[\"Int'l Plan\"].map({1:\"yes\", 0:\"no\"})\n",
+    "churn[\"VMail Plan\"] = churn[\"VMail Plan\"].map({1:\"yes\", 0:\"no\"})\n",
+    "churn[\"Churn?\"] = churn[\"Churn?\"].map({\"1\":\"True.\", \"0\":\"False.\"})\n",
+    "churn.head()\n",
+    "\n",
     "pd.set_option('display.max_columns', 500)\n",
     "churn"
    ]
@@ -727,5 +744,5 @@
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/xgboost_customer_churn/xgboost_customer_churn_neo.ipynb
+++ b/xgboost_customer_churn/xgboost_customer_churn_neo.ipynb
@@ -75,6 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sklearn.datasets import fetch_openml\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- The way to download data is changed to use sklearn fetch_openml because the original link of data source (http://dataminingconsultant.com/DKD2e_data_sets.zip)  refuses to !wget from notebook instance.
- With this change, size of the dataset increases from 3,333 to 5,000 but the modified notebook works similar to the original one.

 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
