### PR TITLE
Add xgboost-data-wrangler hands-on

### DIFF
--- a/workshop/lab_bring-your-own-containers/README.md
+++ b/workshop/lab_bring-your-own-containers/README.md
@@ -14,5 +14,5 @@
 - 各種深層学習フレームワークにおいて Amazon SageMaker 向けのトレーニングスクリプトの書き方を理解していること 
 
 ## コンテンツ
-- Tensorflow 2.0 (MNIST MLP) で[やってみる](./tensorflow2.0/bring_your_own_container_tf2.ipynb)[[Original: SageMaker Containers](https://github.com/aws/sagemaker-containers#sagemaker-containers)]
+- Tensorflow 2.0 (MNIST MLP) で[やってみる](./tensorflow2.0/bring_your_own_container_tf2.ipynb) [[Original: SageMaker Containers](https://github.com/aws/sagemaker-containers#sagemaker-containers)]
 

--- a/workshop/lab_bring-your-own-containers/README.md
+++ b/workshop/lab_bring-your-own-containers/README.md
@@ -1,0 +1,18 @@
+# Amazon SageMaker - Bring Your Own Containers ハンズオンワークショップ
+
+## 概要
+
+このハンズオンでは、深層学習フレームワークのサンプルコードを題材として、実際に Amazon SageMaker で独自コンテナを使うための手順を説明します。
+
+## 対象
+- Amazon SageMaker を使うことを検討しているが、具体的なコードの移行方法が分からない方
+
+### 前提知識
+- Python のコードがある程度書け、簡単なデバッグができること
+- 機械学習、深層学習のコードがある程度読めること
+- Amazon SageMaker や関連する AWS のサービスについて、概要を理解していること
+- 各種深層学習フレームワークにおいて Amazon SageMaker 向けのトレーニングスクリプトの書き方を理解していること 
+
+## コンテンツ
+- Tensorflow 2.0 (MNIST MLP) で[やってみる](./tensorflow2.0/bring_your_own_container_tf2.ipynb)[[Original: SageMaker Containers](https://github.com/aws/sagemaker-containers#sagemaker-containers)]
+

--- a/workshop/lab_bring-your-own-containers/tensorflow2.0/bring_your_own_container_tf2.ipynb
+++ b/workshop/lab_bring-your-own-containers/tensorflow2.0/bring_your_own_container_tf2.ipynb
@@ -1,0 +1,265 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Amazon SageMaker - Bring Your Own Container\n",
+    "## TensorFlow 2.0 編\n",
+    "ここでは TensorFlow2.0 を使ったサンプルコードを題材に、Amazon SageMaker で独自コンテナを用いた機械学習モデルの学習方法を順を追って説明します。トレーニングスクリプトは既に SageMaker 向けに書き換えられた形で準備され、その上で、独自の学習用コンテナを活用します。 トレーニングスクリプトを SageMaker 向けに書き換える際は  [Bring Your Own Model ハンズオンワークショップ](https://github.com/aws-samples/amazon-sagemaker-examples-jp/tree/master/workshop/lab_bring-your-own-model) をご参考に下さい。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from datetime import datetime\n",
+    "import keras\n",
+    "import numpy as np\n",
+    "from keras.datasets import mnist\n",
+    "\n",
+    "import boto3\n",
+    "import sagemaker\n",
+    "from sagemaker import get_execution_role\n",
+    "from sagemaker.estimator import Estimator\n",
+    "\n",
+    "sess = sagemaker.Session()\n",
+    "bucket = sess.default_bucket()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Notebook 上でのデータ準備\n",
+    "\n",
+    "トレーニングを始める前に、予めこの Notebook にデータを準備します。今回は [Keras](https://keras.io/) の MNIST データを活用します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(x_train, y_train), (x_test, y_test) = mnist.load_data()\n",
+    "\n",
+    "os.makedirs(\"./data\", exist_ok = True)\n",
+    "\n",
+    "np.savez('./data/train', image=x_train, label=y_train)\n",
+    "np.savez('./data/test', image=x_test, label=y_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. ローカルでの動作確認\n",
+    "トレーニングジョブを始める前に、この Notebook インスタンス上でコンテナを立て、学習がうまくいくか動作確認しましょう。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "まずは今回学習につかう Dockerfile の中身を確認します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat container/Dockerfile"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "この Notebook インスタンス上の Docker へ Dockerfile を使ってイメージをビルドします。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker build -t tf-2.0 container/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`image_name` で今回ビルドした `tf-2.0` を指定し、`train_instance_type` を`local` にすることで、独自コンテナを使ってこの Notebook 上での学習をすることができます。Dockerfile やトレーニングスクリプトが適切に記述されているか確認しましょう。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sagemaker_session = sagemaker.Session()\n",
+    "\n",
+    "role = get_execution_role()\n",
+    "\n",
+    "estimator = Estimator(image_name='tf-2.0',\n",
+    "                      role=role,\n",
+    "                      hyperparameters={'batch_size': 64,'epochs': 1},\n",
+    "                      train_instance_count=1,\n",
+    "                      train_instance_type='local')\n",
+    "\n",
+    "estimator.fit({'train': 'file://data'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. コンテナのビルドと Amazon ECR への登録\n",
+    "次に学習インスタンスで独自コンテナを活用するために、 今回ビルドしたイメージを Amazon ECR へ登録します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!bash container/build_and_push.sh"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "登録できているかどうか [ECR のコンソール](https://console.aws.amazon.com/ecr) で確認してみましょう。\n",
+    "\n",
+    "学習ジョブにおいてこのコンテナを使うためにイメージパスが必要なので取得しましょう。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = boto3.client('sts')\n",
+    "account = client.get_caller_identity()['Account']\n",
+    "\n",
+    "my_session = boto3.session.Session()\n",
+    "region = my_session.region_name\n",
+    "\n",
+    "algorithm_name = 'sagemaker-tf2.0-example'\n",
+    "\n",
+    "ecr_image = '{}.dkr.ecr.{}.amazonaws.com/{}:latest'.format(account, region, algorithm_name)\n",
+    "\n",
+    "print('使用する Docker Image のURIは {} です。'.format(ecr_image))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. データの S3 へのアップロード\n",
+    "学習ジョブでトレーニングを始めるために、Amazon S3 にデータを準備しておく必要があります。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket_name = sagemaker_session.default_bucket()\n",
+    "input_data = sagemaker_session.upload_data(path='./data', bucket=bucket_name, key_prefix='dataset/mnist')\n",
+    "\n",
+    "print('学習データは {} へアップロードされました。'.format(input_data))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. トレーニングジョブの発行"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_name='tf20-example-{0:%Y%m%d-%H%M%S}'.format(datetime.now())\n",
+    "\n",
+    "\n",
+    "estimator = Estimator(image_name=ecr_image,\n",
+    "                      role=role,\n",
+    "                      hyperparameters={'batch_size': 64,'epochs': 1},\n",
+    "                      train_instance_count=1,\n",
+    "                      train_instance_type='ml.p2.xlarge')\n",
+    "\n",
+    "estimator.fit({'train': '{}'.format(input_data)}, job_name=job_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Amazon S3 へ保存されているモデルの確認\n",
+    "学習されたモデルは S3 へ保存されています。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# モデルファイルとアウトプットファイルのダウンロード\n",
+    "s3 = boto3.client('s3')\n",
+    "s3.download_file(Bucket=bucket, Key= job_name + '/output/model.tar.gz', Filename = 'model.tar.gz')\n",
+    "\n",
+    "# モデルの解凍\n",
+    "!tar -zxvf model.tar.gz"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. まとめ\n",
+    "\n",
+    "TensorFlow 2.0 の Docker image を使った独自コンテナでの学習についてご紹介しました。 Dockerfile を編集することで様々なコンテナをお使い頂けますのでご活用下さい。"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_tensorflow_p36",
+   "language": "python",
+   "name": "conda_tensorflow_p36"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/workshop/lab_bring-your-own-containers/tensorflow2.0/container/Dockerfile
+++ b/workshop/lab_bring-your-own-containers/tensorflow2.0/container/Dockerfile
@@ -1,0 +1,9 @@
+FROM tensorflow/tensorflow:2.0.0a0
+
+RUN pip install sagemaker-containers
+
+# Copies the training code inside the container
+COPY tf_codes/train.py /opt/ml/code/train.py
+
+# Defines train.py as script entry point
+ENV SAGEMAKER_PROGRAM train.py

--- a/workshop/lab_bring-your-own-containers/tensorflow2.0/container/build_and_push.sh
+++ b/workshop/lab_bring-your-own-containers/tensorflow2.0/container/build_and_push.sh
@@ -1,0 +1,33 @@
+# The name of our algorithm
+algorithm_name=sagemaker-tf2.0-example
+
+cd container
+
+chmod +x tf_codes/train.py
+
+account=$(aws sts get-caller-identity --query Account --output text)
+
+# Get the region defined in the current configuration (default to us-west-2 if none defined)
+region=$(aws configure get region)
+
+fullname="${account}.dkr.ecr.${region}.amazonaws.com/${algorithm_name}:latest"
+
+# If the repository doesn't exist in ECR, create it.
+
+aws ecr describe-repositories --repository-names "${algorithm_name}" > /dev/null 2>&1
+
+if [ $? -ne 0 ]
+then
+    aws ecr create-repository --repository-name "${algorithm_name}" > /dev/null
+fi
+
+# Get the login command from ECR and execute it directly
+$(aws ecr get-login --region ${region} --no-include-email)
+
+# Build the docker image locally with the image name and then push it to ECR
+# with the full name.
+
+docker build  -t ${algorithm_name} .
+docker tag ${algorithm_name} ${fullname}
+
+docker push ${fullname}

--- a/workshop/lab_bring-your-own-containers/tensorflow2.0/container/tf_codes/train.py
+++ b/workshop/lab_bring-your-own-containers/tensorflow2.0/container/tf_codes/train.py
@@ -1,0 +1,74 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import os
+import argparse
+
+import numpy as np
+
+import tensorflow as tf
+
+
+def main(args):
+    train_dir = args.train
+    
+    x_train = np.load(os.path.join(train_dir, 'train.npz'))['image']
+    y_train = np.load(os.path.join(train_dir, 'train.npz'))['label']
+    x_test = np.load(os.path.join(train_dir, 'test.npz'))['image']
+    y_test = np.load(os.path.join(train_dir, 'test.npz'))['label']
+    
+    model = tf.keras.models.Sequential([
+        tf.keras.layers.Flatten(input_shape=(28, 28)),
+        tf.keras.layers.Dense(128, activation='relu'),
+        tf.keras.layers.Dropout(0.2),
+        tf.keras.layers.Dense(10, activation='softmax')
+    ])
+
+    model.compile(optimizer='adam',
+                  loss='sparse_categorical_crossentropy',
+                  metrics=['accuracy'])    
+
+    callbacks = []
+    
+    callbacks.append(tf.keras.callbacks.ModelCheckpoint(
+        args.model_dir + '/checkpoint-{epoch}.h5')
+                    )
+
+    model.fit(x_train, y_train,
+              epochs=args.epochs,
+              batch_size=args.batch_size,
+              callbacks=callbacks)
+    
+    model.evaluate(x_test, y_test)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    
+    parser.add_argument('--batch_size',
+                        type=int,
+                        default=128)
+    parser.add_argument('--epochs',
+                        type=int,
+                        default=12)
+    
+    parser.add_argument('--model-dir',
+                        type=str,
+                        default=os.environ['SM_MODEL_DIR'])
+    parser.add_argument('--train',
+                        type=str,
+                        default=os.environ['SM_CHANNEL_TRAIN'])
+
+    args = parser.parse_args()
+    main(args)

--- a/xgboost_data_wrangler/preprocess.py
+++ b/xgboost_data_wrangler/preprocess.py
@@ -1,0 +1,80 @@
+import sys
+from logging import getLogger, StreamHandler, Formatter, INFO
+
+import pandas as pd
+import numpy as np
+import boto3
+from awsglue.utils import getResolvedOptions
+
+
+# ロガーの設定
+logger = getLogger('preprocess')
+[logger.removeHandler(h) for h in logger.handlers]
+
+logger.setLevel(INFO)
+ch = StreamHandler(stream=sys.stdout)
+ch.setLevel(INFO)
+
+formatter = Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+logger.addHandler(ch)
+
+
+if __name__ == '__main__':
+    logger.info('処理を開始')
+    
+    # コマンドライン引数の確認
+    args = getResolvedOptions(sys.argv, ['bucket_name'])
+    bucket_name = args['bucket_name']
+    logger.info(args)
+    logger.info('使用するバケットは s3://{}'.format(bucket_name))
+    
+
+    
+    # データの読み込み
+    s3 = boto3.resource('s3')
+    bucket = s3.Bucket(bucket_name)
+    bucket.download_file(Key='green_tripdata_2019-06.csv',
+                         Filename = 'green_tripdata_2019-06.csv')
+    
+    df = pd.read_csv('green_tripdata_2019-06.csv')
+    logger.info('ロードしたデータのサイズは{}'.format(df.shape))
+    
+    df = df.astype({'VendorID': 'object',
+                    'payment_type': 'object',
+                    'trip_type': 'object'})
+    
+    # 使用しないカラムを削除
+    drop_columns = ['ehail_fee', 'total_amount',
+                    'lpep_dropoff_datetime', 'lpep_pickup_datetime',
+                    'PULocationID', 'DOLocationID', 'RatecodeID']
+    df = pd.concat([df['total_amount'], df.drop(drop_columns, axis=1)], axis=1)
+    
+    # カテゴリカルデータのダミー化
+    df = pd.get_dummies(df)
+    
+    # trip_distanceが0の値を抽出、件数確認
+    rows_drop = df.index[df["trip_distance"] == 0.00]
+    logger.info('移動距離0のデータを削除： {}'.format(df.loc[rows_drop].shape[0]))
+    
+    # trip_distanceが0の値を削除、件数確認
+    df_drop = df.drop(rows_drop)
+    logger.info('移動距離0のデータを削除後のサンプルサイズは {}'.format(df_drop.shape[0]))
+    
+    # データの分割
+    train_data, validation_data = np.split(df.sample(frac=1, random_state=1729), [int(0.7 * len(df))])
+    logger.info('train_data のサイズは: {}'.format(train_data.shape))
+    logger.info('validation_data のサイズは: {}'.format(validation_data.shape))
+    
+    # データの S3 保存
+    train_data.to_csv('train.csv', header=False, index=False)
+    validation_data.to_csv('validation.csv', header=False, index=False)
+    logger.info('S3 へデータを保存')
+    
+    
+    # バケットへのデータのアップロード
+    s3.Object(bucket_name, 'train.csv').upload_file('train.csv')
+    s3.Object(bucket_name, 'validation.csv').upload_file('validation.csv')
+    logger.info('s3://{} へデータがアップロード'.format(bucket_name))
+    
+    logger.info('処理を終了')

--- a/xgboost_data_wrangler/xgboost_data_wrangler.ipynb
+++ b/xgboost_data_wrangler/xgboost_data_wrangler.ipynb
@@ -1,0 +1,463 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Amazon SageMaker ノートブックインスタンスで AWS Glue と Amazon Athena を用いたデータの前処理"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "本ハンズオンでは Amazon SageMaker で機械学習モデルを学習させるためのデータを、Amazon S3、Amazon Athena、AWS Glue をSageMakerと連携させて前処理を行う場合についてご体験頂きます。\n",
+    "\n",
+    "---\n",
+    "### 実施内容\n",
+    "\n",
+    "1. [データの準備](#1.データの準備)\n",
+    "1. [Athenaを使ったデータの確認](#2.Athenaを使ったデータの確認)\n",
+    "1. [Glueによるデータの前処理の実施](#3.Glueによるデータの前処理の実施)\n",
+    "1. [モデルの学習](#4.モデルの学習)\n",
+    "1. [後片付け](#5.後片付け)\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "import boto3\n",
+    "import pandas\n",
+    "\n",
+    "import sagemaker\n",
+    "from sagemaker import get_execution_role\n",
+    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
+    "from sagemaker.session import s3_input\n",
+    "\n",
+    "role = get_execution_role()\n",
+    "sess = sagemaker.Session()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.データの準備\n",
+    "\n",
+    "今回は [TLC Trip Record Data](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page) にある[2019年6月の Green Taxi Trip Records(CSV)](https://s3.amazonaws.com/nyc-tlc/trip+data/green_tripdata_2019-06.csv) を利用します。このデータを今回のユースケースである、ノートブックでの展開が困難であるほど容量が大きいデータだと仮定し、一度 Amazon S3 へアップロードした上で、ノートブックインスタンスから削除します。作成後、[マネジメントコンソール](https://s3.console.aws.amazon.com/s3/home)で確認してみましょう。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# データのダウンロード\n",
+    "!wget https://s3.amazonaws.com/nyc-tlc/trip+data/green_tripdata_2019-06.csv\n",
+    "\n",
+    "# 本ハンズオンで活用するバケットの作成\n",
+    "bucket_name='data-wrangler-{0:%Y%m%d-%H%M%S}'.format(datetime.now())\n",
+    "s3 = boto3.resource('s3')\n",
+    "bucket = s3.Bucket(bucket_name)\n",
+    "bucket.create()\n",
+    "\n",
+    "# バケットへのデータのアップロード\n",
+    "s3.Object(bucket_name, 'green_tripdata_2019-06.csv').upload_file('green_tripdata_2019-06.csv')\n",
+    "print('s3://{} へデータがアップロードされました。'.format(bucket_name))\n",
+    "\n",
+    "# ノートブックインスタンス上でのデータの削除\n",
+    "!rm green_tripdata_2019-06.csv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 2.Athenaを使ったデータの確認\n",
+    "### Amazon Athena のセットアップ"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Athena のデータベースを作成します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ath = boto3.client('athena')\n",
+    "database_name='datawrangler'\n",
+    "\n",
+    "# データベースの作成\n",
+    "ath.start_query_execution(\n",
+    "    QueryString='CREATE DATABASE {}'.format(database_name),\n",
+    "    ResultConfiguration={'OutputLocation': 's3://' + bucket_name + '/athena/'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "作成したデータベースにテーブルを作成します。 [マネジメントコンソール](https://console.aws.amazon.com/athena/home) で確認してみましょう。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_string = \"\"\"\n",
+    "CREATE EXTERNAL TABLE green_tripdata(\n",
+    "  VendorID string, \n",
+    "  lpep_pickup_datetime string,\n",
+    "  lpep_dropoff_datetime string,\n",
+    "  store_and_fwd_flag string,\n",
+    "  RatecodeID string,\n",
+    "  PULocationID string,\n",
+    "  DOLocationID string,\n",
+    "  passenger_count int,\n",
+    "  trip_distance double,\n",
+    "  fare_amount double,\n",
+    "  extra double,\n",
+    "  mta_max double,\n",
+    "  tip_amount double,\n",
+    "  tolls_amount double,\n",
+    "  ehail_fee string,\n",
+    "  improvement_surcharge double,\n",
+    "  total_amount double,\n",
+    "  payment_type string,\n",
+    "  trip_type string,\n",
+    "  congestion_surcharge double\n",
+    "  )\n",
+    "ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' \n",
+    "LOCATION 's3://{}/';\n",
+    "\"\"\".format(bucket_name)\n",
+    "\n",
+    "ath.start_query_execution(\n",
+    "        QueryString=query_string,\n",
+    "        QueryExecutionContext={'Database': database_name},\n",
+    "        ResultConfiguration={'OutputLocation': 's3://' + bucket_name})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Data Wrangler と Athena を使ったデータ分析\n",
+    "2019年9月、 [Github](https://github.com/awslabs/aws-data-wrangler) に AWS Data Wrangler が公開されました。Data Wranglerは、各種AWSサービスからデータを取得して、コーディングをサポートしてくれるPythonのモジュールです。 PyAthena や boto3、を活用する場合に比べて、接続設定などのコーディングが簡素になるため、より一層データ分析や ETL 処理に集中することが出来ます。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Data Wrangler をインストールします。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install awswrangler"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Athea で使うクエリをこのノートブックインスタンス上から実行してみましょう。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import awswrangler\n",
+    "\n",
+    "# データを確認するためのSQL文\n",
+    "sql = \"\"\"\n",
+    "SELECT \n",
+    "    * \n",
+    "FROM\n",
+    "    green_tripdata\n",
+    "ORDER BY \n",
+    "    RAND()\n",
+    "LIMIT\n",
+    "    1000\n",
+    ";\n",
+    "\"\"\"\n",
+    "\n",
+    "session = awswrangler.Session()\n",
+    "df = session.pandas.read_sql_athena(sql=sql,database=database_name)\n",
+    "\n",
+    "# 取得したデータの表示\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "S3 にあるデータを Athena やサンプリングされたデータを用いてノートブックインスタンス上の [Pandas](https://pandas.pydata.org/) を使って探索的データ分析を行い、機械学習モデルの学習に必要な前処理や特徴量作成を検討します。その後、実際の処理は Glue 上で実施します。今回のデータの前処理を行うスクリプトを確認しましょう。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 3.Glueによるデータの前処理の実施"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat preprocess.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "今回準備したスクリプトを S3 へアップロードします。Glue のジョブ作成時にそのスクリプトのパスを指定することで実行が可能です。ジョブ作成時の`Role`を指定して下さい。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Glue で使用するRoleの指定\n",
+    "role = '使用するRoleを指定して下さい'\n",
+    "\n",
+    "# バケットへのデータのアップロード\n",
+    "s3.Object(bucket_name, 'preprocess.py').upload_file('preprocess.py')\n",
+    "print('s3://{} へ Glue のスクリプトがアップロードされました。'.format(bucket_name))\n",
+    "\n",
+    "# Glue のジョブを作成します。\n",
+    "glue = boto3.client('glue')\n",
+    "job = glue.create_job(Name='preprocess', Role=role,\n",
+    "                      Command={'Name': 'pythonshell',\n",
+    "                               'ScriptLocation': 's3://{}/preprocess.py'.format(bucket_name),\n",
+    "                               'PythonVersion': '3'})\n",
+    "# 作成したジョブを開始します。\n",
+    "jobrun = glue.start_job_run(JobName = job['Name'],Arguments = {'--bucket_name': bucket_name} )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "ジョブの実行状況を確認しましょう。`SUCCEEDED` となったら完了です。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "while True:\n",
+    "    status = glue.get_job_run(JobName=job['Name'], RunId=jobrun['JobRunId'])\n",
+    "    print('Glue のジョブのステータスは現在 {} です。'.format(status['JobRun']['JobRunState']))\n",
+    "    if status['JobRun']['JobRunState'] == 'SUCCEEDED':\n",
+    "        break\n",
+    "    else:\n",
+    "        time.sleep(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 4.モデルの学習"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Glue による処理により、S3 のバケット上に `train.csv` と `validation.csv` が作成されています。今回はこのデータをモデルの学習に使います。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# データのパスを指定\n",
+    "input_train = 's3://{}/train.csv'.format(bucket_name)\n",
+    "input_validation = 's3://{}/validation.csv'.format(bucket_name)\n",
+    "\n",
+    "s3_input_train = s3_input(s3_data=input_train, content_type='text/csv')\n",
+    "s3_input_validation = s3_input(s3_data=input_validation, content_type='text/csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "それでは学習を始めましょう。まず、XGBoost のコンテナの場所を取得します。コンテナ自体は SageMaker 側で用意されているので、場所を指定すれば利用可能です。XGBoostのhyperparameterに関する詳細は [github](https://github.com/dmlc/xgboost/blob/master/doc/parameter.rst) もチェックしてください。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "container = get_image_uri(boto3.Session().region_name, 'xgboost')\n",
+    "xgb = sagemaker.estimator.Estimator(container,\n",
+    "                                    role, \n",
+    "                                    train_instance_count=1, \n",
+    "                                    train_instance_type='ml.m4.xlarge',\n",
+    "                                    sagemaker_session=sess)\n",
+    "\n",
+    "xgb.set_hyperparameters(max_depth=5,\n",
+    "                        eta=0.2,\n",
+    "                        gamma=4,\n",
+    "                        min_child_weight=6,\n",
+    "                        subsample=0.8,\n",
+    "                        silent=0,\n",
+    "                        objective='reg:linear',\n",
+    "                        num_round=100)\n",
+    "\n",
+    "xgb.fit({'train': s3_input_train, 'validation': s3_input_validation})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`job completed`という文字が出たら学習の完了です。このモデルを使って推論の実行を行うことができます。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 5.後片付け"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "本ハンズオンで使用したリソースを削除します。今回使ったリソースは下記になります。\n",
+    "- Athena のテーブル\n",
+    "- Glue のジョブ\n",
+    "- Glue のデータベース\n",
+    "- S3 のバケット\n",
+    "\n",
+    "SageMakerへ割り当てられているロールによっては削除の権限がない場合があります。その場合には[マネジメントコンソール](https://console.aws.amazon.com/console/home?)から削除して下さい。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Athena のテーブルを削除します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_string = 'DROP TABLE `green_tripdata`;'\n",
+    "\n",
+    "ath.start_query_execution(\n",
+    "        QueryString=query_string,\n",
+    "        QueryExecutionContext={'Database': database_name},\n",
+    "        ResultConfiguration={'OutputLocation': 's3://' + bucket_name})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Glue のジョブとデータベースを削除します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "glue.delete_job(JobName='preprocess')\n",
+    "glue.delete_database(Name=database_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "S3 のバケットを削除します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 本ハンズオンで活用したバケットの削除\n",
+    "bucket = s3.Bucket(bucket_name)\n",
+    "bucket.delete()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_python3",
+   "language": "python",
+   "name": "conda_python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/xgboost_wine_quality/README.md
+++ b/xgboost_wine_quality/README.md
@@ -1,0 +1,15 @@
+# XGBoost によるワインの品質推定
+
+## はじめに
+本ハンズオンでは機械学習モデルの解釈性をテーマに、どの特徴量がどの程度の影響があるかについて解析する手法について Amazon SageMaker の組み込みアルゴリズム XGBoost を用いて実践します。
+
+## 本ハンズオンで学べる内容
+- SageMaker の組み込みアルゴリズムである XGBoost を用いた機械学習モデルの学習
+- SageMaker を用いた際の XGBoost での特徴量重要度の可視化
+- Partianl Dependency Plot(PDP) による特徴量の変化による目的変数への影響の可視化
+
+## ノートブックについて
+`xgboost_wine_quality_batch.ipynb`  ではPDPを描く際に、特定のカラムを任意の値に変更し、s3へアップロードした上でバッチ変換ジョブで推論を実施します。一方、`xgboost_wine_quality_endpoint.ipynb` では、推論エンドポイントへ変更後のデータを渡して推論を実施します。ハンズオンなどで使用できるインスタンスに制限がある場合には、適切なノートブックを選択下さい。
+
+## 参考
+- [XGBoost tutorial (var imp + partial dependence)](https://www.kaggle.com/chalkalan/xgboost-tutorial-var-imp-partial-dependence)

--- a/xgboost_wine_quality/README.md
+++ b/xgboost_wine_quality/README.md
@@ -9,7 +9,7 @@
 - Partianl Dependency Plot(PDP) による特徴量の変化による目的変数への影響の可視化
 
 ## ノートブックについて
-`xgboost_wine_quality_batch.ipynb`  ではPDPを描く際に、特定のカラムを任意の値に変更し、s3へアップロードした上でバッチ変換ジョブで推論を実施します。一方、`xgboost_wine_quality_endpoint.ipynb` では、推論エンドポイントへ変更後のデータを渡して推論を実施します。ハンズオンなどで使用できるインスタンスに制限がある場合には、適切なノートブックを選択下さい。
+`xgboost_wine_quality_batch.ipynb`  ではPDPを描く際に、特定のカラムを任意の値に変更し、s3へアップロードした上でバッチ変換ジョブで推論を実施します。一方、`xgboost_wine_quality_endpoint.ipynb` では、推論エンドポイントへ変更後のデータを渡して推論を実施します。
 
 ## 参考
 - [XGBoost tutorial (var imp + partial dependence)](https://www.kaggle.com/chalkalan/xgboost-tutorial-var-imp-partial-dependence)

--- a/xgboost_wine_quality/xgboost_wine_quality_batch.ipynb
+++ b/xgboost_wine_quality/xgboost_wine_quality_batch.ipynb
@@ -1,0 +1,467 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# はじめに\n",
+    "本ハンズオンでは機械学習モデルの解釈性をテーマに、どの特徴量がどの程度の影響があるかについて解析する手法について Amazon SageMaker の組み込みアルゴリズム XGBoost を用いて実践します。\n",
+    "\n",
+    "## 本ハンズオンで学べる内容\n",
+    "- SageMaker の組み込みアルゴリズムである XGBoost を用いた機械学習モデルの学習\n",
+    "- SageMaker を用いた際の XGBoost での特徴量重要度の求め方\n",
+    "- SageMaker でのバッチ推論の実施方法\n",
+    "- Partianl Dependency Plot(PDP) による特徴量の変化による目的変数への影響の可視化"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define IAM role\n",
+    "import time\n",
+    "import pickle as pkl\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import boto3\n",
+    "import sagemaker\n",
+    "from sagemaker import get_execution_role\n",
+    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
+    "from sagemaker.predictor import csv_serializer\n",
+    "from sagemaker.session import s3_input\n",
+    "\n",
+    "sess = sagemaker.Session()\n",
+    "role = get_execution_role()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## データの準備\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "今回は [UCI Machine Learning Repogitory](https://archive.ics.uci.edu/ml/index.php) にある \"Wine Quality\" というデータセットを活用します。\n",
+    "\n",
+    "それぞれのワインがアルコール度数や、pH 、残糖量といった計測指標と共に、その品質が 3〜8 で段階的に評価されているデータセットです。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wget https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/winequality-red.csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = pd.read_csv(\"winequality-red.csv\",sep=\";\",encoding=\"utf-8\")\n",
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "各カラムは下記を意味しています。\n",
+    "- alcohol: アルコール度数\n",
+    "- cholorides: 塩化ナトリウム濃度\n",
+    "- citric acid: クエン酸濃度\n",
+    "- density: 密度\n",
+    "- fixed acidity: 酸性度 \n",
+    "- pH: pH\n",
+    "- residual sugar: 残糖含有量\n",
+    "- sulphates: 硫化カリウム含有量\n",
+    "- total sulfur dioxide: 総二酸化硫黄含有量\n",
+    "- free sulfur dioxide: 遊離二酸化硫黄含有量\n",
+    "- volatile acidity: 揮発性酸度\n",
+    "- quality: 品質\n",
+    "\n",
+    "ヒストグラムを描いて、データの分布を確認しましょう。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 特徴量をヒストグラムとして可視化\n",
+    "hist = data.hist(bins=30, sharey=True, figsize=(15, 15))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 相関行列を求める\n",
+    "データを確認する意味で、それぞれの特徴量同士の相関を見てみましょう。`fixed acidity` と `citric acid` や `density` はやや強い相関が見える、`quality` と強い相関のある特徴量があるとは言えない、などの傾向がつかめます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 相関行列を求める\n",
+    "display(data.corr())\n",
+    "pd.plotting.scatter_matrix(data, figsize=(12, 12))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## データの分割\n",
+    "データを学習用、検証用、テスト用データへ分割します。学習＆検証用データで構築したモデルに対してテストデータで推論と、その予測値に対してどの特徴量がどの程度寄与しているか、または変化した際に、どの程度影響を及ぼすのかを解析します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SageMakerの組み込みアルゴリズムへの対応のためデータの並び替え\n",
+    "model_data = pd.concat([data['quality'], data.drop(['quality'], axis=1)], axis=1)\n",
+    "\n",
+    "# 学習用データ、検証用データ、テスト用データへ分割\n",
+    "train_data, validation_data, test_data = np.split(model_data.sample(frac=1, random_state=1729), [int(0.7 * len(model_data)), int(0.9 * len(model_data))])\n",
+    "\n",
+    "# 学習用データ、検証用データの保存\n",
+    "train_data.to_csv('train.csv', header=False, index=False)\n",
+    "validation_data.to_csv('validation.csv', header=False, index=False)\n",
+    "\n",
+    "# アップロード先を指定\n",
+    "bucket = sess.default_bucket()\n",
+    "prefix = 'sagemaker/wine-quality-interpretability' \n",
+    "\n",
+    "# csvファイルとして保存された学習用データ、検証用データをS3バケット上にアップロード\n",
+    "sagemaker_session = sagemaker.Session()\n",
+    "input_train = sagemaker_session.upload_data(path='train.csv', key_prefix=prefix)\n",
+    "input_validation = sagemaker_session.upload_data(path='validation.csv', key_prefix=prefix)\n",
+    "\n",
+    "s3_input_train = s3_input(s3_data=input_train, content_type='text/csv')\n",
+    "s3_input_validation = s3_input(s3_data=input_validation, content_type='text/csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 学習\n",
+    "今回は SageMaker の組み込みアルゴリズムの中にある XGBoost を使います。まず、XGBoost のコンテナの場所を取得します。コンテナ自体は SageMaker 側で用意されているのでそれを指定します。学習のためにハイパーパラメータや、学習のインスタンスの数やタイプを指定して学習を開始します。XGBoostのhyperparameterに関する詳細は [github](https://github.com/dmlc/xgboost/blob/master/doc/parameter.rst) をご確認下さい。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "container = get_image_uri(boto3.Session().region_name, 'xgboost')\n",
+    "\n",
+    "# 学習ジョブの名前を指定して下さい。XXXXは適宜変更して下さい。\n",
+    "job_name=\"xgb-wine-interpretability-XXXX\"\n",
+    "\n",
+    "# どのような学習インスタンスを使うのかの設定\n",
+    "xgb = sagemaker.estimator.Estimator(container,\n",
+    "                                    role, \n",
+    "                                    train_instance_count=1, \n",
+    "                                    train_instance_type='ml.m4.xlarge',\n",
+    "                                    sagemaker_session=sess)\n",
+    "\n",
+    "# XGBoostアルゴリズムのハイパラ設定\n",
+    "xgb.set_hyperparameters(max_depth=5,\n",
+    "                        alpha=0.05,\n",
+    "                        eta=0.2,\n",
+    "                        min_child_weight=2,\n",
+    "                        subsample=0.8,\n",
+    "                        objective='reg:linear',\n",
+    "                        num_round=100)\n",
+    "\n",
+    "# 学習の開始\n",
+    "xgb.fit({'train': s3_input_train, 'validation': s3_input_validation}, job_name=job_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 学習させたモデルから特徴量重要度を取得\n",
+    "\n",
+    "SageMaker で学習されたモデルは s3 のバケットに`model.tar.gz`として保存されています。\n",
+    "XGBoost では、どの特徴量がモデルの予測精度の向上に役立ったかは学習時に計算され、`xgboost-model`の中に保存されており、`get_score()` メソッドで呼び出せます。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "ノートブックインスタンス上に XGBoost のライブラリをインストールすることで、学習済モデルを活用することができます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!conda install -c conda-forge -y xgboost"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "s3 のバケットから学習済みのモデルをダウンロードし、特徴量重要度をプロットして可視化してみましょう。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 学習させたxgboostモデルのダウンロード\n",
+    "s3 = boto3.client('s3')\n",
+    "s3.download_file(Bucket=bucket, Key= job_name + '/output/model.tar.gz', Filename = 'model.tar.gz')\n",
+    "\n",
+    "# xgboostモデルの解凍\n",
+    "!tar -zxvf model.tar.gz\n",
+    "\n",
+    "# ダウンロードしてきたxgboostモデルの読み込み\n",
+    "xgb_model = pkl.load(open(\"xgboost-model\", 'rb'))\n",
+    "\n",
+    "# 特徴量重要度を読み込むためのデータフレームの準備\n",
+    "dict_varImp = xgb_model.get_score(importance_type = 'weight')\n",
+    "df_ = pd.DataFrame(dict_varImp, index = ['varImp']).transpose().reset_index()\n",
+    "df_.columns = ['feature', 'fscore']\n",
+    "\n",
+    "# 上位10個の特徴量重要度を描写\n",
+    "df_['fscore'] = df_['fscore'] / df_['fscore'].max()\n",
+    "df_.sort_values('fscore', ascending = False, inplace = True)\n",
+    "df_ = df_[0:11]\n",
+    "df_.sort_values('fscore', ascending = True, inplace = True)\n",
+    "\n",
+    "fscore = df_['fscore']\n",
+    "feature = df_['feature']\n",
+    "\n",
+    "# 特徴量重要度が特徴量の名前を保持していないため、データセットのカラム名からマッピング\n",
+    "mapper = {'f{0}'.format(i): v for i, v in enumerate(model_data.columns.drop('quality'))}\n",
+    "mapped_feature = [mapper[f] for f in df_[\"feature\"]]\n",
+    "\n",
+    "plt.figure(figsize=(10,10))\n",
+    "plt.title('XGBoost Feature Importance Top10', fontsize = 15)\n",
+    "plt.yticks(fontsize=15)\n",
+    "plt.barh(mapped_feature,fscore)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Partial Dependency Plotの活用\n",
+    "Partial Dependency Plotは特徴量の寄与度だけでなく、その特徴量の変化した際にどの程度目的変数が変化するかを確認するために活用されます。 手順は下記になります。\n",
+    "\n",
+    "- 検証データのある点を元にして、影響を見たい1つの特徴量だけを変化させたデータセットを作成する\n",
+    "- そのデータに対して学習済モデルで推論をを実施する\n",
+    "- 1つの特徴量が変化するとそれぞれのデータ点の予測はどう変わるのかを計算する\n",
+    "- 各サンプルの変化や、その平均をプロットする\n",
+    "\n",
+    "今回は特徴量重要度が高かった `volatile acidity` に対して 0.2 〜 1.0 の間で変化させたデータセットを作成し、それぞれにおいて推論することで Partial Dependency Plotを描いていきます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 対象となる特徴量を設定      \n",
+    "target_column = 'volatile acidity'\n",
+    "target_range = [round(0.2 + 0.05*x, 2) for x in range(0, 17, 1)]\n",
+    "\n",
+    "# アップロード先を指定\n",
+    "bucket = sess.default_bucket()\n",
+    "prefix = 'sagemaker/wine-quality-interpretability'\n",
+    "\n",
+    "input_data_list = []\n",
+    "for v in target_range:\n",
+    "    print(\"各サンプルで、{} が {} だった場合のデータセットを作成し s3 へアップロード\".format(target_column, v))\n",
+    "    \n",
+    "    # 全てのサンプルデータの`alcohol`の値が v になったデータセットを作成し保存\n",
+    "    pdp_df = data.copy().drop(['quality'], axis=1)\n",
+    "    pdp_df[target_column] = v    \n",
+    "    pdp_channel = prefix + '/test_pdp_{}_{}'.format(target_column, v)       \n",
+    "    pdp_df.to_csv(\"test_X_{}_{}.csv\".format(target_column, v), header=False, index=False)\n",
+    "    \n",
+    "    # csvファイルとして保存された学習用データ、検証用データをS3バケット上にアップロード\n",
+    "    input_data = sagemaker_session.upload_data(path=\"test_X_{}_{}.csv\".format(target_column, v), bucket=bucket, key_prefix=pdp_channel)\n",
+    "    \n",
+    "    # アップロードされたデータ\n",
+    "    # s3_input_test = s3_input(s3_data=input_data, content_type='text/csv')\n",
+    "\n",
+    "    # アップロード先のパス\n",
+    "    s3_pdp_data = 's3://{}/{}'.format(bucket, pdp_channel)\n",
+    "    s3_output_location = 's3://{}/{}/output'.format(bucket, prefix)\n",
+    "    \n",
+    "    input_data_list.append(input_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## SageMaker のバッチ変換ジョブを用いた推論\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# バッチ変換用のインスタンスを設定\n",
+    "xgb_transformer = xgb.transformer(instance_count=1,\n",
+    "                                  instance_type='ml.m4.xlarge',\n",
+    "                                  strategy='MultiRecord',\n",
+    "                                  assemble_with='Line',\n",
+    "                                  output_path=s3_output_location)\n",
+    "\n",
+    "job_target_column = target_column.replace(' ', '-')\n",
+    "\n",
+    "for i in range(len(target_range)):\n",
+    "    # バッチ変換用ジョブの実行\n",
+    "    xgb_transformer.transform(data=input_data_list[i],\n",
+    "                              job_name =  \"transform-{}-{}\".format(job_target_column, i),\n",
+    "                              content_type='text/csv',\n",
+    "                              split_type='Line')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "それぞれのバッチ変換ジョブの状態を boto3 の SageMaker クライアントで `describe_transform_job()` を実行することで確認し、全てのジョブが終わるまで待ちます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = boto3.client('sagemaker')\n",
+    "\n",
+    "while True:\n",
+    "    response_list = []\n",
+    "    \n",
+    "    for i in range(len(target_range)):\n",
+    "        TransformJobName = \"transform-{}-{}\".format(job_target_column, i)\n",
+    "        response = client.describe_transform_job(TransformJobName=TransformJobName)\n",
+    "        response_list.append(response['TransformJobStatus'])\n",
+    "    \n",
+    "    if all(response == 'Completed' for response in response_list):\n",
+    "        print(\"Transform finished\")\n",
+    "        break\n",
+    "        \n",
+    "    elif any(response == 'Failed' for response in response_list):\n",
+    "        print(\"Transform Failed\")\n",
+    "        break\n",
+    "        \n",
+    "    else:\n",
+    "        print('Transform InProgress')\n",
+    "        time.sleep(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`volatile acidity` の値を変化させたそれぞれのサンプルにおいて品質がどのように変化するか、またそのデータセット全体における平均はどのように変化するか見てみましょう。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# バッチ変換データのダウンロード\n",
+    "s3 = boto3.client('s3')\n",
+    "df_plot = pd.DataFrame()\n",
+    "\n",
+    "for i in range(len(target_range)):\n",
+    "    s3.download_file(Bucket=bucket,\n",
+    "                     Key= prefix + \"/output/\" + \"test_X_{}_{}.csv.out\".format(target_column, target_range[i]),\n",
+    "                     Filename = \"test_X_{}_{}.csv.out\".format(job_target_column, target_range[i]))\n",
+    "    \n",
+    "    df_tmp =  pd.read_csv(\"test_X_{}_{}.csv.out\".format(job_target_column, target_range[i]), names=[str(target_range[i])])\n",
+    "    df_plot = pd.concat([df_plot, df_tmp], axis=1)\n",
+    "\n",
+    "    \n",
+    "# プロットの実行\n",
+    "plt.figure(figsize=(10,10))\n",
+    "plt.title('Partial Dependency Plot: volatile acidity', fontsize = 15)\n",
+    "plt.yticks(fontsize=15)\n",
+    "plt.xlabel('volatile acidity', fontsize = 15)\n",
+    "plt.ylabel('quality', fontsize = 15)\n",
+    "plt.plot(df_plot.T.index,df_plot.T, linewidth=0.2, color='blue')\n",
+    "plt.plot(df_plot.mean().index,df_plot.mean(), linewidth=5, color='red')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "このプロットからは `volatile acidity` の上昇が品質の悪化に緩やかに影響し、特に 0.9 以上になると品質の劣化が著しくなる傾向が見えます。また、それぞれのサンプルでその影響具合が異ることも見てとれます。 "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_python3",
+   "language": "python",
+   "name": "conda_python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/xgboost_wine_quality/xgboost_wine_quality_batch.ipynb
+++ b/xgboost_wine_quality/xgboost_wine_quality_batch.ipynb
@@ -167,7 +167,7 @@
    "metadata": {},
    "source": [
     "## 学習\n",
-    "今回は SageMaker の組み込みアルゴリズムの中にある XGBoost を使います。まず、XGBoost のコンテナの場所を取得します。コンテナ自体は SageMaker 側で用意されているのでそれを指定します。学習のためにハイパーパラメータや、学習のインスタンスの数やタイプを指定して学習を開始します。XGBoostのhyperparameterに関する詳細は [github](https://github.com/dmlc/xgboost/blob/master/doc/parameter.rst) をご確認下さい。"
+    "今回は SageMaker の組み込みアルゴリズムの中にある XGBoost を使います。まず、XGBoost のコンテナの場所を取得します。コンテナ自体は SageMaker 側で用意されているのでそれを指定します。学習のためにハイパーパラメータや、学習のインスタンスの数やタイプを指定して学習を開始します。XGBoost の hyperparameter に関する詳細は [github](https://github.com/dmlc/xgboost/blob/master/doc/parameter.rst) をご確認下さい。"
    ]
   },
   {
@@ -179,7 +179,7 @@
     "container = get_image_uri(boto3.Session().region_name, 'xgboost')\n",
     "\n",
     "# 学習ジョブの名前を指定して下さい。XXXXは適宜変更して下さい。\n",
-    "job_name=\"xgb-wine-interpretability-XXXX\"\n",
+    "job_name=\"xgb-wine-interpretability-XXXXX\"\n",
     "\n",
     "# どのような学習インスタンスを使うのかの設定\n",
     "xgb = sagemaker.estimator.Estimator(container,\n",
@@ -279,14 +279,14 @@
    "metadata": {},
    "source": [
     "## Partial Dependency Plotの活用\n",
-    "Partial Dependency Plotは特徴量の寄与度だけでなく、その特徴量の変化した際にどの程度目的変数が変化するかを確認するために活用されます。 手順は下記になります。\n",
+    "Partial Dependency Plot は特徴量の寄与度だけでなく、その特徴量の変化した際にどの程度目的変数が変化するかを確認するために活用されます。 手順は下記になります。\n",
     "\n",
     "- 検証データのある点を元にして、影響を見たい1つの特徴量だけを変化させたデータセットを作成する\n",
     "- そのデータに対して学習済モデルで推論をを実施する\n",
     "- 1つの特徴量が変化するとそれぞれのデータ点の予測はどう変わるのかを計算する\n",
     "- 各サンプルの変化や、その平均をプロットする\n",
     "\n",
-    "今回は特徴量重要度が高かった `volatile acidity` に対して 0.2 〜 1.0 の間で変化させたデータセットを作成し、それぞれにおいて推論することで Partial Dependency Plotを描いていきます。"
+    "今回は特徴量重要度が高かった `volatile acidity` に対して 0.2 〜 1.0 の間で変化させたデータセットを作成し、それぞれにおいて推論することで Partial Dependency Plot を描いていきます。"
    ]
   },
   {
@@ -302,6 +302,8 @@
     "# アップロード先を指定\n",
     "bucket = sess.default_bucket()\n",
     "prefix = 'sagemaker/wine-quality-interpretability'\n",
+    "pdp_channel = prefix + '/test_pdp'\n",
+    "\n",
     "\n",
     "input_data_list = []\n",
     "for v in target_range:\n",
@@ -309,28 +311,19 @@
     "    \n",
     "    # 全てのサンプルデータの`alcohol`の値が v になったデータセットを作成し保存\n",
     "    pdp_df = data.copy().drop(['quality'], axis=1)\n",
-    "    pdp_df[target_column] = v    \n",
-    "    pdp_channel = prefix + '/test_pdp_{}_{}'.format(target_column, v)       \n",
+    "    pdp_df[target_column] = v  \n",
     "    pdp_df.to_csv(\"test_X_{}_{}.csv\".format(target_column, v), header=False, index=False)\n",
     "    \n",
     "    # csvファイルとして保存された学習用データ、検証用データをS3バケット上にアップロード\n",
-    "    input_data = sagemaker_session.upload_data(path=\"test_X_{}_{}.csv\".format(target_column, v), bucket=bucket, key_prefix=pdp_channel)\n",
-    "    \n",
-    "    # アップロードされたデータ\n",
-    "    # s3_input_test = s3_input(s3_data=input_data, content_type='text/csv')\n",
-    "\n",
-    "    # アップロード先のパス\n",
-    "    s3_pdp_data = 's3://{}/{}'.format(bucket, pdp_channel)\n",
-    "    s3_output_location = 's3://{}/{}/output'.format(bucket, prefix)\n",
-    "    \n",
-    "    input_data_list.append(input_data)"
+    "    input_data = sagemaker_session.upload_data(path=\"test_X_{}_{}.csv\".format(target_column, v), bucket=bucket, key_prefix=pdp_channel)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## SageMaker のバッチ変換ジョブを用いた推論\n"
+    "### SageMaker のバッチ変換ジョブを用いた推論\n",
+    "SageMaker のバッチ変換ジョブを用いてサーバーレスに推論ジョブを実行します。"
    ]
   },
   {
@@ -340,56 +333,27 @@
    "outputs": [],
    "source": [
     "# バッチ変換用のインスタンスを設定\n",
+    "input_s3 = \"s3://{}/{}\".format(bucket,pdp_channel)\n",
+    "output_s3 = 's3://{}/{}/output'.format(bucket, prefix)\n",
+    "\n",
     "xgb_transformer = xgb.transformer(instance_count=1,\n",
     "                                  instance_type='ml.m4.xlarge',\n",
     "                                  strategy='MultiRecord',\n",
     "                                  assemble_with='Line',\n",
-    "                                  output_path=s3_output_location)\n",
+    "                                  output_path=output_s3)\n",
     "\n",
-    "job_target_column = target_column.replace(' ', '-')\n",
-    "\n",
-    "for i in range(len(target_range)):\n",
-    "    # バッチ変換用ジョブの実行\n",
-    "    xgb_transformer.transform(data=input_data_list[i],\n",
-    "                              job_name =  \"transform-{}-{}\".format(job_target_column, i),\n",
-    "                              content_type='text/csv',\n",
-    "                              split_type='Line')"
+    "xgb_transformer.transform(data=input_s3,\n",
+    "                          job_name =  \"transform-test-20191020-6\",\n",
+    "                          content_type='text/csv',\n",
+    "                          split_type='Line',\n",
+    "                          wait=True)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "それぞれのバッチ変換ジョブの状態を boto3 の SageMaker クライアントで `describe_transform_job()` を実行することで確認し、全てのジョブが終わるまで待ちます。"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "client = boto3.client('sagemaker')\n",
-    "\n",
-    "while True:\n",
-    "    response_list = []\n",
-    "    \n",
-    "    for i in range(len(target_range)):\n",
-    "        TransformJobName = \"transform-{}-{}\".format(job_target_column, i)\n",
-    "        response = client.describe_transform_job(TransformJobName=TransformJobName)\n",
-    "        response_list.append(response['TransformJobStatus'])\n",
-    "    \n",
-    "    if all(response == 'Completed' for response in response_list):\n",
-    "        print(\"Transform finished\")\n",
-    "        break\n",
-    "        \n",
-    "    elif any(response == 'Failed' for response in response_list):\n",
-    "        print(\"Transform Failed\")\n",
-    "        break\n",
-    "        \n",
-    "    else:\n",
-    "        print('Transform InProgress')\n",
-    "        time.sleep(30)"
+    "### Partial Dependency Plotの可視化"
    ]
   },
   {
@@ -412,9 +376,9 @@
     "for i in range(len(target_range)):\n",
     "    s3.download_file(Bucket=bucket,\n",
     "                     Key= prefix + \"/output/\" + \"test_X_{}_{}.csv.out\".format(target_column, target_range[i]),\n",
-    "                     Filename = \"test_X_{}_{}.csv.out\".format(job_target_column, target_range[i]))\n",
+    "                     Filename = \"test_X_{}_{}.csv.out\".format(target_column, target_range[i]))\n",
     "    \n",
-    "    df_tmp =  pd.read_csv(\"test_X_{}_{}.csv.out\".format(job_target_column, target_range[i]), names=[str(target_range[i])])\n",
+    "    df_tmp =  pd.read_csv(\"test_X_{}_{}.csv.out\".format(target_column, target_range[i]), names=[str(target_range[i])])\n",
     "    df_plot = pd.concat([df_plot, df_tmp], axis=1)\n",
     "\n",
     "    \n",

--- a/xgboost_wine_quality/xgboost_wine_quality_endpoint.ipynb
+++ b/xgboost_wine_quality/xgboost_wine_quality_endpoint.ipynb
@@ -352,6 +352,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Partial Dependency Plotの可視化"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "それぞれのサンプルにおいて、`volatile acidity` の値を変化させたデータセットを作成し、推論を実行します。"
    ]
   },

--- a/xgboost_wine_quality/xgboost_wine_quality_endpoint.ipynb
+++ b/xgboost_wine_quality/xgboost_wine_quality_endpoint.ipynb
@@ -1,0 +1,459 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# はじめに\n",
+    "本ハンズオンでは機械学習モデルの解釈性をテーマに、どの特徴量がどの程度の影響があるかについて解析する手法について Amazon SageMaker の組み込みアルゴリズム XGBoost を用いて実践します。\n",
+    "\n",
+    "## 本ハンズオンで学べる内容\n",
+    "- SageMaker の組み込みアルゴリズムである XGBoost を用いた機械学習モデルの学習\n",
+    "- SageMaker を用いた際の XGBoost での特徴量重要度の求め方\n",
+    "- SageMaker での推論エンドポイントを用いた推論の実施方法\n",
+    "- Partianl Dependency Plot(PDP) による特徴量の変化による目的変数への影響の可視化"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define IAM role\n",
+    "import time\n",
+    "import pickle as pkl\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import boto3\n",
+    "import sagemaker\n",
+    "from sagemaker import get_execution_role\n",
+    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
+    "from sagemaker.predictor import csv_serializer\n",
+    "from sagemaker.session import s3_input\n",
+    "\n",
+    "sess = sagemaker.Session()\n",
+    "role = get_execution_role()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## データの準備\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "今回は [UCI Machine Learning Repogitory](https://archive.ics.uci.edu/ml/index.php) にある \"Wine Quality\" というデータセットを活用します。\n",
+    "\n",
+    "それぞれのワインがアルコール度数や、pH 、残糖量といった計測指標と共に、その品質が 3〜8 で段階的に評価されているデータセットです。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wget https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/winequality-red.csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = pd.read_csv(\"winequality-red.csv\",sep=\";\",encoding=\"utf-8\")\n",
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "各カラムは下記を意味しています。\n",
+    "- alcohol: アルコール度数\n",
+    "- cholorides: 塩化ナトリウム濃度\n",
+    "- citric acid: クエン酸濃度\n",
+    "- density: 密度\n",
+    "- fixed acidity: 酸性度 \n",
+    "- pH: pH\n",
+    "- residual sugar: 残糖含有量\n",
+    "- sulphates: 硫化カリウム含有量\n",
+    "- total sulfur dioxide: 総二酸化硫黄含有量\n",
+    "- free sulfur dioxide: 遊離二酸化硫黄含有量\n",
+    "- volatile acidity: 揮発性酸度\n",
+    "- quality: 品質\n",
+    "\n",
+    "ヒストグラムを描いて、データの分布を確認しましょう。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 特徴量をヒストグラムとして可視化\n",
+    "hist = data.hist(bins=30, sharey=True, figsize=(15, 15))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 相関行列を求める\n",
+    "データを確認する意味で、それぞれの特徴量同士の相関を見てみましょう。`fixed acidity` と `citric acid` や `density` はやや強い相関が見える、`quality` と強い相関のある特徴量があるとは言えない、などの傾向がつかめます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 相関行列を求める\n",
+    "display(data.corr())\n",
+    "pd.plotting.scatter_matrix(data, figsize=(12, 12))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## データの分割\n",
+    "データを学習用、検証用、テスト用データへ分割します。学習と検証用データで構築したモデルに対してテストデータで推論と、その予測値に対してどの特徴量がどの程度寄与しているか、または変化した際に、どの程度影響を及ぼすのかを解析します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SageMakerの組み込みアルゴリズムへの対応のためデータの並び替え\n",
+    "model_data = pd.concat([data['quality'], data.drop(['quality'], axis=1)], axis=1)\n",
+    "\n",
+    "# 学習用データ、検証用データ、テスト用データへ分割\n",
+    "train_data, validation_data, test_data = np.split(model_data.sample(frac=1, random_state=1729), [int(0.7 * len(model_data)), int(0.9 * len(model_data))])\n",
+    "\n",
+    "# 学習用データ、検証用データの保存\n",
+    "train_data.to_csv('train.csv', header=False, index=False)\n",
+    "validation_data.to_csv('validation.csv', header=False, index=False)\n",
+    "\n",
+    "# アップロード先を指定\n",
+    "bucket = sess.default_bucket()\n",
+    "prefix = 'sagemaker/wine-quality-interpretability' \n",
+    "\n",
+    "# csvファイルとして保存された学習用データ、検証用データをS3バケット上にアップロード\n",
+    "sagemaker_session = sagemaker.Session()\n",
+    "input_train = sagemaker_session.upload_data(path='train.csv', key_prefix=prefix)\n",
+    "input_validation = sagemaker_session.upload_data(path='validation.csv', key_prefix=prefix)\n",
+    "\n",
+    "s3_input_train = s3_input(s3_data=input_train, content_type='text/csv')\n",
+    "s3_input_validation = s3_input(s3_data=input_validation, content_type='text/csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 学習\n",
+    "今回は SageMaker の組み込みアルゴリズムの中にある XGBoost を使います。まず、XGBoost のコンテナの場所を取得します。コンテナ自体は SageMaker 側で用意されているのでそれを指定します。学習のためにハイパーパラメータや、学習のインスタンスの数やタイプを指定して学習を開始します。XGBoost の hyperparameter に関する詳細は [github](https://github.com/dmlc/xgboost/blob/master/doc/parameter.rst) をご確認下さい。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "container = get_image_uri(boto3.Session().region_name, 'xgboost')\n",
+    "\n",
+    "# 学習ジョブの名前を指定して下さい。XXXXは適宜変更して下さい。\n",
+    "job_name=\"xgb-wine-interpretability-XXXX\"\n",
+    "\n",
+    "# どのような学習インスタンスを使うのかの設定\n",
+    "xgb = sagemaker.estimator.Estimator(container,\n",
+    "                                    role, \n",
+    "                                    train_instance_count=1, \n",
+    "                                    train_instance_type='ml.m4.xlarge',\n",
+    "                                    sagemaker_session=sess)\n",
+    "\n",
+    "# XGBoostアルゴリズムのハイパラ設定\n",
+    "xgb.set_hyperparameters(max_depth=5,\n",
+    "                        alpha=0.05,\n",
+    "                        eta=0.2,\n",
+    "                        min_child_weight=2,\n",
+    "                        subsample=0.8,\n",
+    "                        objective='reg:linear',\n",
+    "                        num_round=100)\n",
+    "\n",
+    "# 学習の開始\n",
+    "xgb.fit({'train': s3_input_train, 'validation': s3_input_validation}, job_name=job_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 学習させたモデルから特徴量重要度を取得\n",
+    "\n",
+    "SageMaker で学習されたモデルは s3 のバケットに`model.tar.gz`として保存されています。\n",
+    "XGBoost では、どの特徴量がモデルの予測精度の向上に役立ったかは学習時に計算され、`xgboost-model`の中に保存されており、`get_score()` メソッドで呼び出せます。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "ノートブックインスタンス上に XGBoost のライブラリをインストールすることで、学習済モデルを活用することができます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!conda install -c conda-forge -y xgboost"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "s3 のバケットから学習済みのモデルをダウンロードし、特徴量重要度をプロットして可視化してみましょう。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 学習させたxgboostモデルのダウンロード\n",
+    "s3 = boto3.client('s3')\n",
+    "s3.download_file(Bucket=bucket, Key= job_name + '/output/model.tar.gz', Filename = 'model.tar.gz')\n",
+    "\n",
+    "# xgboostモデルの解凍\n",
+    "!tar -zxvf model.tar.gz\n",
+    "\n",
+    "# ダウンロードしてきたxgboostモデルの読み込み\n",
+    "xgb_model = pkl.load(open(\"xgboost-model\", 'rb'))\n",
+    "\n",
+    "# 特徴量重要度を読み込むためのデータフレームの準備\n",
+    "dict_varImp = xgb_model.get_score(importance_type = 'weight')\n",
+    "df_ = pd.DataFrame(dict_varImp, index = ['varImp']).transpose().reset_index()\n",
+    "df_.columns = ['feature', 'fscore']\n",
+    "\n",
+    "# 上位10個の特徴量重要度を描写\n",
+    "df_['fscore'] = df_['fscore'] / df_['fscore'].max()\n",
+    "df_.sort_values('fscore', ascending = False, inplace = True)\n",
+    "df_ = df_[0:11]\n",
+    "df_.sort_values('fscore', ascending = True, inplace = True)\n",
+    "\n",
+    "fscore = df_['fscore']\n",
+    "feature = df_['feature']\n",
+    "\n",
+    "# 特徴量重要度が特徴量の名前を保持していないため、データセットのカラム名からマッピング\n",
+    "mapper = {'f{0}'.format(i): v for i, v in enumerate(model_data.columns.drop('quality'))}\n",
+    "mapped_feature = [mapper[f] for f in df_[\"feature\"]]\n",
+    "\n",
+    "plt.figure(figsize=(10,10))\n",
+    "plt.title('XGBoost Feature Importance Top10', fontsize = 15)\n",
+    "plt.yticks(fontsize=15)\n",
+    "plt.barh(mapped_feature,fscore)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Partial Dependency Plotの活用\n",
+    "Partial Dependency Plotは特徴量の寄与度だけでなく、その特徴量の変化した際にどの程度目的変数が変化するかを確認するために活用されます。 手順は下記になります。\n",
+    "\n",
+    "- 検証データのある点を元にして、影響を見たい1つの特徴量だけを変化させたデータセットを作成する\n",
+    "- そのデータに対して学習済モデルで推論をを実施する\n",
+    "- 1つの特徴量が変化するとそれぞれのデータ点の予測はどう変わるのかを計算する\n",
+    "- 各サンプルの変化や、その平均をプロットする\n",
+    "\n",
+    "今回は特徴量重要度が高かった `volatile acidity` に対して 0.2 〜 1.0 の間で変化させたデータセットを作成し、それぞれにおいて推論することで Partial Dependency Plotを描いていきます。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 推論エンドポイントへのデプロイ\n",
+    "学習済モデルで推論ができるよう、推論エンドポイントを作成します。deploy()を実行することで、エンドポイントを作成してモデルをデプロイでき、モデルを使った推論ができるようになります。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xgb_predictor = xgb.deploy(initial_instance_count = 1, instance_type = 'ml.m4.xlarge')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "現在、エンドポイントをホストしている状態で、これを利用して簡単に予測を行うことができます。予測は http の POST の request を送るだけです。 ここではデータを numpy の array の形式で送って、予測を得られるようにしたいと思います。しかし、endpoint は numpy の array を受け取ることはできません。このために、csv_serializer を利用して、csv 形式に変換して送ることができます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 推論エンドポイントを活用するためのデータ形式の変換準備\n",
+    "xgb_predictor.content_type = 'text/csv'\n",
+    "xgb_predictor.serializer = csv_serializer\n",
+    "xgb_predictor.deserializer = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "作成済みのテストデータを受け取ると、これをデフォルト500行ずつのデータにわけて、エンドポイントに送信する predict という関数を用意します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# データを500行ずつ小分けにしてエンドポイントにする関数を準備\n",
+    "def predict(data, rows=500):\n",
+    "    split_array = np.array_split(data, int(data.shape[0] / float(rows) + 1))\n",
+    "    predictions = ''\n",
+    "    for array in split_array:\n",
+    "        predictions = ','.join([predictions, xgb_predictor.predict(array).decode('utf-8')])\n",
+    "\n",
+    "    return np.fromstring(predictions[1:], sep=',')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "それぞれのサンプルにおいて、`volatile acidity` の値を変化させたデータセットを作成し、推論を実行します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 対象となる特徴量と変化させる値域を設定      \n",
+    "target_column = 'volatile acidity'\n",
+    "target_range = [round(0.2 + 0.05*x, 2) for x in range(0, 17, 1)]\n",
+    "\n",
+    "df_plot = pd.DataFrame()\n",
+    "\n",
+    "for v in target_range:\n",
+    "    print(\"各サンプルで、{} が {} だった場合で推論中\".format(target_column, v))\n",
+    "    \n",
+    "    # 全てのサンプルデータの taeget_column の値が v になったデータセットを作成\n",
+    "    pdp_df = data.copy().drop(['quality'], axis=1)\n",
+    "    pdp_df[target_column] = v\n",
+    "    \n",
+    "    # 予測値を格納するための配列を準備\n",
+    "    dtest = pdp_df.values\n",
+    "    predictions = []\n",
+    "    \n",
+    "    # 予測の実行\n",
+    "    for i in range(dtest.shape[0]):\n",
+    "        predictions.append(predict(dtest[i:i+1,:]))\n",
+    "    predictions = np.array(predictions).squeeze()\n",
+    "    \n",
+    "    df_tmp = pd.DataFrame(predictions, columns=[str(v)])\n",
+    "    df_plot = pd.concat([df_plot, df_tmp], axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# プロットの実行\n",
+    "plt.figure(figsize=(10,10))\n",
+    "plt.title('Partial Dependency Plot: volatile acidity', fontsize = 15)\n",
+    "plt.yticks(fontsize=15)\n",
+    "plt.xlabel('volatile acidity', fontsize = 15)\n",
+    "plt.ylabel('quality', fontsize = 15)\n",
+    "plt.plot(df_plot.T.index,df_plot.T, linewidth=0.2, color='blue')\n",
+    "plt.plot(df_plot.mean().index,df_plot.mean(), linewidth=5, color='red')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "このプロットからは `volatile acidity` の上昇が品質の悪化に緩やかに影響し、特に 0.9 以上になると品質の劣化が著しくなる傾向が見えます。また、それぞれのサンプルでその影響具合が異ることも見てとれます。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## エンドポイントの削除\n",
+    "エンドポイントは起動したままだとコストがかかります。不要な場合は削除します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sagemaker.Session().delete_endpoint(xgb_predictor.endpoint)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_python3",
+   "language": "python",
+   "name": "conda_python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Data Wrangling hands-on based on the following blog article.
- [AWS Data Wranglerを使って、簡単にETL処理を実現する](https://aws.amazon.com/jp/blogs/news/how-to-use-aws-data-wrangler/)
-  EDA utilizing Amazon Athena via awswrangler on the notebook instance
- ETL (S3 -> AWS Glue -> S3) via boto3 glue client on the notebook instance
- Train xgboost model with preprocessed data on the S3 bucket

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
