### PR TITLE
fix pandas version error

### DIFF
--- a/random_cut_forest/random_cut_forest.ipynb
+++ b/random_cut_forest/random_cut_forest.ipynb
@@ -173,7 +173,7 @@
     "                      num_trees=50)\n",
     "\n",
     "# automatically upload the training data to S3 and run the training job\n",
-    "rcf.fit(rcf.record_set(taxi_data.value.as_matrix().reshape(-1,1)))"
+    "rcf.fit(rcf.record_set(taxi_data.value.to_numpy().reshape(-1,1)))"
    ]
   },
   {
@@ -276,7 +276,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "taxi_data_numpy = taxi_data.value.as_matrix().reshape(-1,1)\n",
+    "taxi_data_numpy = taxi_data.value.to_numpy().reshape(-1,1)\n",
     "results = rcf_inference.predict(taxi_data_numpy)\n",
     "\n",
     "scores = [datum['score'] for datum in results['scores']]\n",
@@ -325,7 +325,7 @@
     "\n",
     "ax1.set_ylim(0, 40000)\n",
     "ax2.set_ylim(min(scores), 1.4*max(scores))\n",
-    "fig.set_figwidth(10)"
+    "fig.set_figwidth(16)"
    ]
   },
   {
@@ -520,7 +520,7 @@
     "ax2.tick_params('y', colors='C1')\n",
     "ax1.set_ylim(0, 40000)\n",
     "ax2.set_ylim(min(scores), 1.4*max(scores))\n",
-    "fig.set_figwidth(10)"
+    "fig.set_figwidth(16)"
    ]
   },
   {
@@ -569,7 +569,7 @@
     "ax2.tick_params('y', colors='C1')\n",
     "ax1.set_ylim(0, 40000)\n",
     "ax2.set_ylim(min(scores), 1.4*max(scores))\n",
-    "fig.set_figwidth(10)"
+    "fig.set_figwidth(16)"
    ]
   },
   {
@@ -607,7 +607,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.10"
   },
   "notice": "Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.",
   "nteract": {


### PR DESCRIPTION
*Issue #, if available:*
An error occurs due to the version upgrade of pandas.

*Description of changes:*
from `rcf.fit(rcf.record_set(taxi_data.value.as_matrix().reshape(-1,1)))`
to `rcf.fit(rcf.record_set(taxi_data.value.to_numpy().reshape(-1,1)))`

from `taxi_data_numpy = taxi_data.value.as_matrix().reshape(-1,1)`
to `taxi_data_numpy = taxi_data.value.to_numpy().reshape(-1,1)`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
